### PR TITLE
Fix base API URL

### DIFF
--- a/simple-tickets-ui/src/apis/abstractApi.ts
+++ b/simple-tickets-ui/src/apis/abstractApi.ts
@@ -7,7 +7,7 @@ export abstract class AbstractApi<T> {
   /**
    * ホスト
    */
-  protected baseUrl = "localhost:8080";
+  protected baseUrl = "http://localhost:8080";
 
   /**
    * APIによるリソースの一覧取得
@@ -17,7 +17,7 @@ export abstract class AbstractApi<T> {
    */
   protected async list(apiPath: string, params?: ApiParams): Promise<T[]> {
     const queryString = ApiParamsUtil.getQueryString(params);
-    const url = `${this.baseUrl}${queryString}`;
+    const url = `${this.baseUrl}${apiPath}${queryString}`;
     const response = await fetch(url, {
       method: 'GET',
       mode: 'cors'


### PR DESCRIPTION
## Summary
- fix missing http in base URL
- include path when forming requests

## Testing
- `npm test --silent` *(fails: react-scripts not found)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842e20a830083288c8ad3b982f75513