### PR TITLE
Add Kanban board screen

### DIFF
--- a/simple-tickets-ui/src/App.tsx
+++ b/simple-tickets-ui/src/App.tsx
@@ -1,30 +1,11 @@
 import React from 'react';
-import logo from './logo.svg';
 import './App.css';
-import { TicketApi } from './apis/ticket/ticketApi';
+import { KanbanBoard } from './components/KanbanBoard';
 
 function App() {
-  const api = new TicketApi();
-  api.list().then(tickets => {
-    console.log(tickets[0]);
-  });
-
   return (
     <div className="App">
-      <header className="App-header">
-        <img src={logo} className="App-logo" alt="logo" />
-        <p>
-          Edit <code>src/App.tsx</code> and save to reload.
-        </p>
-        <a
-          className="App-link"
-          href="https://reactjs.org"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Learn React
-        </a>
-      </header>
+      <KanbanBoard />
     </div>
   );
 }

--- a/simple-tickets-ui/src/apis/bord/bord.ts
+++ b/simple-tickets-ui/src/apis/bord/bord.ts
@@ -1,0 +1,8 @@
+export interface Bord {
+  id: string;
+  projectId: string;
+  title: string;
+  description: string;
+  bordColumns: string[];
+  createdDate: Date;
+}

--- a/simple-tickets-ui/src/apis/bord/bordApi.ts
+++ b/simple-tickets-ui/src/apis/bord/bordApi.ts
@@ -1,0 +1,14 @@
+import { AbstractApi } from "../abstractApi";
+import { Bord } from "./bord";
+
+export class BordApi extends AbstractApi<Bord> {
+  protected apiPath = "/bords";
+
+  list(): Promise<Bord[]> {
+    return super.list(this.apiPath);
+  }
+
+  protected handleError(response: Response): void {
+    throw new Error("Failed to fetch bords: " + response.statusText);
+  }
+}

--- a/simple-tickets-ui/src/apis/bordColumn/bordColumn.ts
+++ b/simple-tickets-ui/src/apis/bordColumn/bordColumn.ts
@@ -1,0 +1,7 @@
+export interface BordColumn {
+  id: string;
+  projectId: string;
+  title: string;
+  ticketIds: string[];
+  createdDate: Date;
+}

--- a/simple-tickets-ui/src/apis/bordColumn/bordColumnApi.ts
+++ b/simple-tickets-ui/src/apis/bordColumn/bordColumnApi.ts
@@ -1,0 +1,14 @@
+import { AbstractApi } from "../abstractApi";
+import { BordColumn } from "./bordColumn";
+
+export class BordColumnApi extends AbstractApi<BordColumn> {
+  protected apiPath = "/bordColumns";
+
+  list(): Promise<BordColumn[]> {
+    return super.list(this.apiPath);
+  }
+
+  protected handleError(response: Response): void {
+    throw new Error("Failed to fetch bord columns: " + response.statusText);
+  }
+}

--- a/simple-tickets-ui/src/components/KanbanBoard.css
+++ b/simple-tickets-ui/src/components/KanbanBoard.css
@@ -1,0 +1,23 @@
+.kanban-board {
+  padding: 20px;
+}
+
+.kanban-columns {
+  display: flex;
+  gap: 16px;
+}
+
+.kanban-column {
+  background: #f4f5f7;
+  border-radius: 4px;
+  padding: 8px;
+  width: 200px;
+}
+
+.kanban-ticket {
+  background: #fff;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  padding: 4px 8px;
+  margin-bottom: 8px;
+}

--- a/simple-tickets-ui/src/components/KanbanBoard.tsx
+++ b/simple-tickets-ui/src/components/KanbanBoard.tsx
@@ -1,0 +1,64 @@
+import React, { useEffect, useState } from 'react';
+import { TicketApi } from '../apis/ticket/ticketApi';
+import { Ticket } from '../apis/ticket/ticket';
+import { BordApi } from '../apis/bord/bordApi';
+import { Bord } from '../apis/bord/bord';
+import { BordColumnApi } from '../apis/bordColumn/bordColumnApi';
+import { BordColumn } from '../apis/bordColumn/bordColumn';
+import './KanbanBoard.css';
+
+export const KanbanBoard: React.FC = () => {
+  const [bord, setBord] = useState<Bord | null>(null);
+  const [columns, setColumns] = useState<BordColumn[]>([]);
+  const [tickets, setTickets] = useState<Ticket[]>([]);
+
+  useEffect(() => {
+    const bordApi = new BordApi();
+    const columnApi = new BordColumnApi();
+    const ticketApi = new TicketApi();
+
+    async function fetchData() {
+      const bords = await bordApi.list();
+      if (bords.length > 0) {
+        const firstBord = bords[0];
+        setBord(firstBord);
+        const allColumns = await columnApi.list();
+        const filtered = allColumns.filter(c => firstBord.bordColumns.includes(c.id));
+        setColumns(filtered);
+      }
+      const ts = await ticketApi.list();
+      setTickets(ts);
+    }
+    fetchData();
+  }, []);
+
+  const renderColumn = (column: BordColumn) => {
+    const columnTickets = column.ticketIds
+      .map(id => tickets.find(t => t.id === id))
+      .filter((t): t is Ticket => t !== undefined);
+
+    return (
+      <div key={column.id} className="kanban-column">
+        <h3>{column.title}</h3>
+        {columnTickets.map(t => (
+          <div key={t.id} className="kanban-ticket">
+            {t.title}
+          </div>
+        ))}
+      </div>
+    );
+  };
+
+  if (!bord) {
+    return <div>Loading...</div>;
+  }
+
+  return (
+    <div className="kanban-board">
+      <h2>{bord.title}</h2>
+      <div className="kanban-columns">
+        {columns.map(renderColumn)}
+      </div>
+    </div>
+  );
+};


### PR DESCRIPTION
## Summary
- implement a simple Kanban board component
- add API wrappers for bords and bord columns
- swap default app UI for the Kanban board

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration)*

------
https://chatgpt.com/codex/tasks/task_e_684a607b16b4832889d0446731bf6d82